### PR TITLE
cmd2 recent version is not available to python <= 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cmd2==0.8.4
 virtualenv
 six
 werkzeug

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py35, pep8
+envlist = py27
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
This library is critical to python-saharaclient work properly. The problem has been solved by setting the cmd2 version in the requirements.